### PR TITLE
Fix Vercel deployment name conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🥗 DIETAS NUTRIMED 
+# 🥗 Nutrimed App
 
 **Aplicación completa de gestión nutricional personalizada basada en principios mediterráneos**
 
@@ -52,8 +52,8 @@
 
 ### 1. Clonar el repositorio
 ```bash
-git clone https://github.com/tu-usuario/dietas-nutrimed.git
-cd dietas-nutrimed
+git clone https://github.com/tu-usuario/nutrimed-app.git
+cd nutrimed-app
 ```
 
 ### 2. Instalar dependencias
@@ -73,7 +73,7 @@ cp .env.example .env.local
 Edita `.env.local` con tus configuraciones:
 ```env
 # Base de datos
-DATABASE_URL="postgresql://username:password@localhost:5432/dietas_nutrimed"
+DATABASE_URL="postgresql://username:password@localhost:5432/nutrimed_app"
 
 # NextAuth
 NEXTAUTH_URL="http://localhost:3000"
@@ -113,7 +113,7 @@ La aplicación estará disponible en `http://localhost:3000`
 ## 📁 Estructura del Proyecto
 
 ```
-dietas-nutrimed/
+nutrimed-app/
 ├── app/                    # App Router de Next.js
 │   ├── api/               # API Routes
 │   ├── auth/              # Páginas de autenticación

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dietas-nutrimed",
+  "name": "nutrimed-app",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
The project name 'dietas-nutrimed' was causing a conflict during Vercel deployment. This is likely because the name is already in use in the Vercel account.

This commit changes the project name in `package.json` to `nutrimed-app` to resolve the conflict.

The `README.md` file has also been updated to reflect the new project name for consistency in the documentation.