### PR TITLE
Fix: Handle session loading state on onboarding page

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 import { useForm } from "react-hook-form"
@@ -27,7 +27,7 @@ const profileSchema = z.object({
 export default function OnboardingPage() {
   const [loading, setLoading] = useState(false)
   const [step, setStep] = useState(1)
-  const { data: session } = useSession()
+  const { data: session, status } = useSession()
   const router = useRouter()
   const { toast } = useToast()
 
@@ -42,6 +42,12 @@ export default function OnboardingPage() {
       goal: "MAINTAIN",
     },
   })
+
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/auth/signin');
+    }
+  }, [status, router]);
 
   async function onSubmit(values: z.infer<typeof profileSchema>) {
     setLoading(true)
@@ -102,9 +108,12 @@ export default function OnboardingPage() {
     }
   }
 
-  if (!session) {
-    router.push("/auth/signin")
-    return null
+  if (status === "loading") {
+    return <div className="flex justify-center items-center min-h-screen">Cargando...</div>;
+  }
+
+  if (status === "unauthenticated") {
+    return null; // The useEffect will handle the redirect
   }
 
   const nextStep = () => setStep(step + 1)


### PR DESCRIPTION
This commit resolves a `ReferenceError: location is not defined` that occurred during server-side rendering of the `/onboarding` page.

The error was caused by calling `router.push` directly in the component's render logic based on the session status. This is problematic because navigation is a client-side action that cannot be executed on the server during pre-rendering.

The fix refactors the component to:
1.  Use the `status` returned from the `useSession` hook.
2.  Display a loading state while the session is being checked.
3.  Use a `useEffect` hook to perform the redirect only on the client-side after the session status is confirmed to be "unauthenticated".